### PR TITLE
Removing child content view controller from its parent 

### DIFF
--- a/Xamarin-Sidebar/SidebarController.cs
+++ b/Xamarin-Sidebar/SidebarController.cs
@@ -253,6 +253,10 @@ namespace SidebarNavigation
 		public void ChangeContentView(UIViewController newContentView) {
 			if (_contentAreaView != null)
 				_contentAreaView.RemoveFromSuperview();
+            
+            if (ContentAreaController != null)
+                ContentAreaController.RemoveFromParentViewController ();
+            
 			ContentAreaController = newContentView;
 			SetVisibleView();
 			CloseMenu();


### PR DESCRIPTION
Prevents from potential memory leaks if a new content view controller is created each time you navigate.
