### PR TITLE
Fixed height issue which causes black bar

### DIFF
--- a/Xamarin-Sidebar/SidebarController.cs
+++ b/Xamarin-Sidebar/SidebarController.cs
@@ -256,6 +256,7 @@ namespace SidebarNavigation
 			var menuFrame = MenuAreaController.View.Frame;
 			menuFrame.X = MenuLocation == MenuLocations.Left ? 0 : View.Frame.Width - MenuWidth;
 			menuFrame.Width = MenuWidth;
+            menuFrame.Height = View.Frame.Height;
 			MenuAreaController.View.Frame = menuFrame;
 		}
 


### PR DESCRIPTION
Make sure the menu occupies the full height of the view. When using a nib as View the height is always reset to 600 pixels, leaving a black bar at the bottom of the menu if the height of the view is bigger then 600px.
