### PR TITLE
making the Sidebar class public

### DIFF
--- a/Xamarin-Sidebar/Sidebar.cs
+++ b/Xamarin-Sidebar/Sidebar.cs
@@ -21,7 +21,7 @@ using nuint = global::System.UInt32;
 
 namespace SidebarNavigation
 {
-	internal class Sidebar
+	public class Sidebar
 	{
 		public const float DefaultFlingPercentage = 0.5f;
 		public const float DefaultFlingVelocity = 800f;


### PR DESCRIPTION
I found there are cases where I would like to use the Sidebar class without using SidebarController. Making Sidebar public allows for its use outside of the library.
