### PR TITLE
Feature: Dark overlay view over the content ViewController while menus are open

### DIFF
--- a/Xamarin-Sidebar/Sidebar.cs
+++ b/Xamarin-Sidebar/Sidebar.cs
@@ -27,7 +27,7 @@ namespace SidebarNavigation
 		public const float DefaultFlingVelocity = 800f;
 		public const int DefaultMenuWidth = 260;
 		public const int DefaultGestureActiveArea = 50;
-
+		public const float DefaultDarkOverlayAlpha = 0.54f;
 
 		public static readonly nfloat SlideSpeed = 0.2f;
 
@@ -36,6 +36,7 @@ namespace SidebarNavigation
 		private bool _disabled = false;
 		private bool _disablePanGesture = false;
 		private bool _shadowShown = false;
+		private bool _darkOverlayShown = false;
 
 		private SidebarContentArea _sidebarContentArea;
 		private SidebarMenuArea _sidebarMenuArea;
@@ -108,6 +109,10 @@ namespace SidebarNavigation
 
 		public bool HasShadowing { get; set; }
 
+		public bool HasDarkOverlay { get; set; }
+
+		public float DarkOverlayAlpha { get; set; }
+
 		public bool ReopenOnRotate { get; set; }
 
 		public bool Disabled {
@@ -135,12 +140,13 @@ namespace SidebarNavigation
 			if (IsOpen || Disabled)
 				return;
 			ShowShadow();
+
 			_sidebarContentArea.BeforeOpenAnimation();
 			UIView.Animate(
 				Sidebar.SlideSpeed, 
 				0, 
 				UIViewAnimationOptions.CurveEaseInOut,
-				() => { _sidebarContentArea.OpenAnimation(MenuLocation, MenuWidth); },
+				() => { _sidebarContentArea.OpenAnimation(MenuLocation, MenuWidth); ShowDarkOverlay(); },
 				() => {
 					_sidebarContentArea.AfterOpenAnimation(TapGesture);
 					IsOpen = true;
@@ -156,12 +162,13 @@ namespace SidebarNavigation
 				animate ? Sidebar.SlideSpeed : 0, 
 				0, 
 				UIViewAnimationOptions.CurveEaseInOut, 
-				() => { _sidebarContentArea.CloseAnimation(); }, 
+				() => { _sidebarContentArea.CloseAnimation(); HideDarkOverlay();}, 
 				() => {
 					_sidebarContentArea.AfterCloseAnimation(TapGesture);
 					IsOpen = false;
 				});
 			HideShadow();
+
 		}
 
 		public void ChangeContentView(UIViewController newContentView) {
@@ -217,6 +224,22 @@ namespace SidebarNavigation
 			_shadowShown = false;
 		}
 
+		private void ShowDarkOverlay()
+		{
+			if(!HasDarkOverlay || _darkOverlayShown)
+				return;
+			_sidebarContentArea.ShowDarkOverlay(DarkOverlayAlpha);
+			_darkOverlayShown = true;
+		}
+
+		private void HideDarkOverlay()
+		{
+			if(!HasDarkOverlay  || !_darkOverlayShown)
+				return;
+			_sidebarContentArea.HideDarkOverlay();
+			_darkOverlayShown = false;
+		}
+
 		private void SetDefaults() {
 			FlingPercentage = Sidebar.DefaultFlingPercentage;
 			FlingVelocity = Sidebar.DefaultFlingVelocity;
@@ -225,6 +248,8 @@ namespace SidebarNavigation
 			MenuWidth = Sidebar.DefaultMenuWidth;
 			HasShadowing = true;
 			ReopenOnRotate = true;
+			HasDarkOverlay = false;
+			DarkOverlayAlpha = DefaultDarkOverlayAlpha;
 		}
 
 		private void SetupGestureRecognizers() {

--- a/Xamarin-Sidebar/SidebarContentArea.cs
+++ b/Xamarin-Sidebar/SidebarContentArea.cs
@@ -25,13 +25,15 @@ namespace SidebarNavigation
 	{
 		private bool _ignorePan;
 		private nfloat _panOriginX;
-
+		private UIView _viewOverlay;
 
 		public UIViewController ContentViewController { get; set; }
 
 
 		public SidebarContentArea(UIViewController viewController) {
 			ContentViewController = viewController;
+
+			InitializeDarkOverlay();
 		}
 
 
@@ -48,6 +50,30 @@ namespace SidebarNavigation
 			ContentViewController.View.Layer.ShadowRadius = 0.0f;
 			ContentViewController.View.Layer.ShadowOpacity = 0.0f;
 			ContentViewController.View.Layer.ShadowColor = UIColor.Clear.CGColor;
+		}
+
+		public void ShowDarkOverlay(float darkOverlayAlpha) 
+		{
+			_viewOverlay.Alpha = darkOverlayAlpha;
+		}
+
+		private void InitializeDarkOverlay()
+		{
+			if(_viewOverlay != null) 
+				return;
+
+			_viewOverlay = new UIView { BackgroundColor = UIColor.Black};
+			_viewOverlay.Alpha = 0f;
+			_viewOverlay.Frame = ContentViewController.View.Bounds;
+			_viewOverlay.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+
+			ContentViewController.View.AddSubview(_viewOverlay);
+			ContentViewController.View.BringSubviewToFront(_viewOverlay);
+		}
+
+		public void HideDarkOverlay() 
+		{
+			_viewOverlay.Alpha = 0f;
 		}
 
 		public void BeforeOpenAnimation() {
@@ -158,7 +184,7 @@ namespace SidebarNavigation
 					Sidebar.SlideSpeed, 
 					0, 
 					UIViewAnimationOptions.CurveEaseInOut,
-					() => { ContentViewController.View.Frame = new RectangleF(0, 0, ContentViewController.View.Frame.Width, ContentViewController.View.Frame.Height); },
+					() => { ContentViewController.View.Frame = new RectangleF(0, 0, ContentViewController.View.Frame.Width, ContentViewController.View.Frame.Height); HideDarkOverlay(); },
 					() => {});
 			}
 		}
@@ -171,7 +197,7 @@ namespace SidebarNavigation
 					Sidebar.SlideSpeed, 
 					0, 
 					UIViewAnimationOptions.CurveEaseInOut,
-					() => { CloseAnimation(); }, 
+					() => { CloseAnimation(); HideDarkOverlay(); }, 
 					() => { });
 			}
 		}

--- a/Xamarin-Sidebar/SidebarController.cs
+++ b/Xamarin-Sidebar/SidebarController.cs
@@ -113,7 +113,23 @@ namespace SidebarNavigation
 		public bool HasShadowing {
 			get { return _sidebar.HasShadowing; }
 			set { _sidebar.HasShadowing = value; }
-		}
+		} 
+
+		/// <summary>
+		/// Gets or sets a value indicating whether there should be a dark overlay effect on the content view.
+		/// </summary>
+		public bool HasDarkOverlay {
+			get { return _sidebar.HasDarkOverlay; }
+			set { _sidebar.HasDarkOverlay = value; }
+		} 
+
+		/// <summary>
+		/// Gets or sets a value indicating the dark overlay alpha.
+		/// </summary>
+		public float DarkOverlayAlpha {
+			get { return _sidebar.DarkOverlayAlpha; }
+			set { _sidebar.DarkOverlayAlpha = value; }
+		} 
 
 		/// <summary>
 		/// Determines if the menu should be reopened after the screen is roated.

--- a/component/samples/UnifiedSample/UnifiedSample/RootViewController.cs
+++ b/component/samples/UnifiedSample/UnifiedSample/RootViewController.cs
@@ -24,6 +24,7 @@ namespace Sample
 			// create a slideout navigation controller with the top navigation controller and the menu view controller
 			SidebarController = new SidebarController(this, new IntroController(), new SideMenuController());
 			SidebarController.MenuLocation = MenuLocations.Left;
+			SidebarController.HasDarkOverlay = true;
 		}
 	}
 }


### PR DESCRIPTION
This feature allows users to display a dark overlay over the content ViewController while left/right menu is open, just the way Google's NavigationDrawer [works](https://material.google.com/patterns/navigation-drawer.html#navigation-drawer-content).

By default the feature is disabled, so there won't be any surprises.

Users have also the possibility to configure the overlay's alpha (by default is 0.54f).

I have modified the UnifiedSample to showcase this.