### PR TITLE
Provides a solution for #82

### DIFF
--- a/Xamarin-Sidebar/Sidebar.cs
+++ b/Xamarin-Sidebar/Sidebar.cs
@@ -272,7 +272,7 @@ namespace SidebarNavigation
 			TapGesture.AddTarget (() => CloseMenu());
 			TapGesture.NumberOfTapsRequired = 1;
 			PanGesture = new UIPanGestureRecognizer {
-				Delegate = new SlideoutPanDelegate(),
+				Delegate = new SlideoutPanDelegate(this),
 				MaximumNumberOfTouches = 1,
 				MinimumNumberOfTouches = 1
 			};
@@ -280,11 +280,22 @@ namespace SidebarNavigation
 		}
 
 
+		/// <summary>
+		/// Default pan gesture delegate used to start menu sliding
+		/// when appropriate.
+		/// </summary>
 		private class SlideoutPanDelegate : UIGestureRecognizerDelegate
 		{
-			public override bool ShouldReceiveTouch (UIGestureRecognizer recognizer, UITouch touch)
+			private readonly Sidebar _sidebar;
+
+			public SlideoutPanDelegate(Sidebar sidebar)
 			{
-				return true;
+				_sidebar = sidebar;
+			}
+			
+			public override bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
+			{
+				return _sidebar._sidebarContentArea.TouchInActiveArea(touch, _sidebar);
 			}
 		}
 	}

--- a/Xamarin-Sidebar/SidebarContentArea.cs
+++ b/Xamarin-Sidebar/SidebarContentArea.cs
@@ -24,7 +24,6 @@ namespace SidebarNavigation
 {
 	internal class SidebarContentArea
 	{
-		private bool _ignorePan;
 		private nfloat _panOriginX;
 		private UIView _viewOverlay;
 
@@ -121,27 +120,35 @@ namespace SidebarNavigation
 		public void Pan(Sidebar sidebar)
 		{
 			if (sidebar.PanGesture.State == UIGestureRecognizerState.Began) {
-				PanBegan(sidebar.PanGesture, sidebar.MenuLocation, sidebar.GestureActiveArea);
-			} else if (!_ignorePan && (sidebar.PanGesture.State == UIGestureRecognizerState.Changed)) {
+				PanBegan();
+			} else if (sidebar.PanGesture.State == UIGestureRecognizerState.Changed) {
 				PanChanged(sidebar);
-			} else if (!_ignorePan && (sidebar.PanGesture.State == UIGestureRecognizerState.Ended || 
-									   sidebar.PanGesture.State == UIGestureRecognizerState.Cancelled)) {
+			} else if (sidebar.PanGesture.State == UIGestureRecognizerState.Ended || 
+			           sidebar.PanGesture.State == UIGestureRecognizerState.Cancelled) {
 				PanEnded(sidebar);
 			}
 		}
 
+		/// <summary>
+		/// Returns whether a certain touch is within the area that should
+		/// activate the pan gesture sliding out the menu.
+		/// </summary>
+		/// <param name="touch"></param>
+		/// <param name="sidebar"></param>
+		/// <returns></returns>
+		public bool TouchInActiveArea(UITouch touch, Sidebar sidebar)
+		{
+			var view = ContentViewController.View;
+			var position = touch.LocationInView(view).X;
+			var area = sidebar.GestureActiveArea;
 
-		private void PanBegan(UIPanGestureRecognizer panGesture, MenuLocations menuLocation, nfloat gestureActiveArea) {
-			_panOriginX = ContentViewController.View.Frame.X;
-			_ignorePan = PanGestureInActiveArea(panGesture, menuLocation, gestureActiveArea);
+			return sidebar.MenuLocation == MenuLocations.Left ? 
+				position < area : 
+				position > (view.Bounds.Width - area);
 		}
 
-		private bool PanGestureInActiveArea(UIPanGestureRecognizer panGesture, MenuLocations menuLocation, nfloat gestureActiveArea) {
-			var position = panGesture.LocationInView(ContentViewController.View).X;
-			if (menuLocation == MenuLocations.Left)
-				return position > gestureActiveArea;
-			else
-				return position < ContentViewController.View.Bounds.Width - gestureActiveArea;
+		private void PanBegan() {
+			_panOriginX = ContentViewController.View.Frame.X;
 		}
 
 		private void PanChanged(Sidebar sidebar) {

--- a/Xamarin-Sidebar/SidebarController.cs
+++ b/Xamarin-Sidebar/SidebarController.cs
@@ -23,7 +23,7 @@ namespace SidebarNavigation
 {
 	public class SidebarController : UIViewController {
 
-		private Sidebar _sidebar;
+		private readonly Sidebar _sidebar;
 
 
 		/// <summary>
@@ -42,7 +42,7 @@ namespace SidebarNavigation
 		/// <param name="contentViewController">
 		/// The view controller for the content area.
 		/// </param>
-		/// <param name="navigationViewController">
+		/// <param name="menuViewController">
 		/// The view controller for the side menu.
 		/// </param>
 		public SidebarController(
@@ -70,7 +70,6 @@ namespace SidebarNavigation
 		/// </summary>
 		public event EventHandler<bool> StateChangeHandler;
 
-
 		/// <summary>
 		/// The view controller shown in the content area.
 		/// </summary>
@@ -82,7 +81,11 @@ namespace SidebarNavigation
 		/// </summary>
 		public UIViewController MenuAreaController { get { return _sidebar.MenuViewController; } }
 
-
+		/// <summary>
+		/// Exposes the underlying sidebar object
+		/// </summary>
+		public Sidebar Sidebar => _sidebar;
+		
 		/// <summary>
 		/// Determines the percent of width to complete slide action.
 		/// </summary>


### PR DESCRIPTION
This PR makes the following changes to accomodate #82 :

- The `SlideoutPanDelegate` is updated to only respond to initial touches within the active area
- The `_ignorePan` functionality is no longer needed and removed
- `SidebarController._sidebar` is exposed in a public `Sidebar` property so more elaborate changes can be made to its gestures if necessary.